### PR TITLE
feat: Add GitHub commit history view to share page

### DIFF
--- a/app/api/share/[shareId]/commits/route.ts
+++ b/app/api/share/[shareId]/commits/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCommitHistory } from '@/lib/github';
+import { getShareDetails } from '@/lib/share';
+import prisma from '@/lib/prisma';
+import { decrypt } from '@/lib/crypto';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ shareId: string }> }
+) {
+  try {
+    const { shareId } = await params;
+    const { searchParams } = new URL(request.url);
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const perPage = parseInt(searchParams.get('per_page') || '30', 10);
+
+    // Verify share access
+    const sessionId = request.cookies.get('viewer_session_id')?.value;
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const session = await prisma.viewerSession.findUnique({
+      where: { sessionId, shareId },
+    });
+
+    if (!session || session.expiresAt < new Date()) {
+      return NextResponse.json({ error: 'Session expired' }, { status: 401 });
+    }
+
+    // Get share details
+    const shareData = await getShareDetails(shareId);
+    
+    // Decrypt the access token
+    const decryptedToken = decrypt(shareData.encryptedToken);
+
+    // Fetch commit history
+    const commits = await getCommitHistory(
+      shareData.repoName,
+      shareData.repoOwner,
+      decryptedToken,
+      page,
+      perPage
+    );
+
+    return NextResponse.json(commits);
+  } catch (error) {
+    console.error('Error fetching commits:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch commits' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/editor/CommitHistory.tsx
+++ b/components/editor/CommitHistory.tsx
@@ -1,0 +1,235 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { GitCommit, Calendar, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface Commit {
+  sha: string;
+  message: string;
+  author: {
+    name: string;
+    email: string;
+    date: string;
+    avatar: string | null;
+    username: string | null;
+  };
+  committer: {
+    name: string;
+    email: string;
+    date: string;
+  };
+  url: string;
+  stats?: {
+    additions: number;
+    deletions: number;
+    total: number;
+  };
+}
+
+interface CommitHistoryProps {
+  shareId: string;
+}
+
+export default function CommitHistory({ shareId }: CommitHistoryProps) {
+  const [commits, setCommits] = useState<Commit[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  useEffect(() => {
+    fetchCommits(1);
+  }, [shareId]);
+
+  const fetchCommits = async (pageNum: number) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(`/api/share/${shareId}/commits?page=${pageNum}&per_page=30`, {
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch commits');
+      }
+
+      const data = await response.json();
+      
+      if (pageNum === 1) {
+        setCommits(data);
+      } else {
+        setCommits((prev: Commit[]) => [...prev, ...data]);
+      }
+
+      setHasMore(data.length === 30);
+      setPage(pageNum);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load commits');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMore = () => {
+    fetchCommits(page + 1);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSecs = Math.floor(diffMs / 1000);
+    const diffMins = Math.floor(diffSecs / 60);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffDays > 7) {
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    } else if (diffDays > 0) {
+      return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+    } else if (diffHours > 0) {
+      return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    } else if (diffMins > 0) {
+      return `${diffMins} minute${diffMins > 1 ? 's' : ''} ago`;
+    } else {
+      return 'just now';
+    }
+  };
+
+  const getCommitMessage = (message: string) => {
+    const lines = message.split('\n');
+    return {
+      title: lines[0],
+      description: lines.slice(1).join('\n').trim(),
+    };
+  };
+
+  if (loading && commits.length === 0) {
+    return (
+      <div className="space-y-4 p-6">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="border-border-default flex items-start space-x-3 border-b pb-4">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <div className="border-border-default bg-bg-muted text-fg-default rounded-lg border p-4">
+          <p className="text-sm">Error: {error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (commits.length === 0) {
+    return (
+      <div className="p-6">
+        <div className="border-border-default bg-bg-muted text-fg-muted rounded-lg border p-8 text-center">
+          <GitCommit className="mx-auto mb-3 h-12 w-12 opacity-50" />
+          <p className="text-sm">No commits found</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-6">
+        <div className="mb-4">
+          <h2 className="text-fg-default text-lg font-semibold">Commit History</h2>
+          <p className="text-fg-muted text-sm">{commits.length} commits</p>
+        </div>
+
+        <div className="space-y-0">
+          {commits.map((commit, index) => {
+            const { title, description } = getCommitMessage(commit.message);
+            return (
+              <div
+                key={commit.sha}
+                className={`border-border-default group flex items-start space-x-3 border-b py-4 last:border-b-0 ${
+                  index === 0 ? 'pt-0' : ''
+                }`}
+              >
+                <div className="flex-shrink-0">
+                  {commit.author.avatar ? (
+                    <img
+                      src={commit.author.avatar}
+                      alt={commit.author.name}
+                      className="h-10 w-10 rounded-full"
+                    />
+                  ) : (
+                    <div className="bg-bg-muted text-fg-muted flex h-10 w-10 items-center justify-center rounded-full">
+                      <User className="h-5 w-5" />
+                    </div>
+                  )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1">
+                    <a
+                      href={commit.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-fg-default hover:text-fg-accent block font-medium transition-colors"
+                    >
+                      {title}
+                    </a>
+                    {description && (
+                      <p className="text-fg-muted mt-1 whitespace-pre-wrap text-sm">
+                        {description}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="text-fg-muted flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                    <span className="flex items-center space-x-1">
+                      <User className="h-3 w-3" />
+                      <span className="font-medium">
+                        {commit.author.username || commit.author.name}
+                      </span>
+                    </span>
+                    <span className="flex items-center space-x-1">
+                      <Calendar className="h-3 w-3" />
+                      <span>{formatDate(commit.author.date)}</span>
+                    </span>
+                    <a
+                      href={commit.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-fg-accent font-mono transition-colors"
+                    >
+                      {commit.sha.substring(0, 7)}
+                    </a>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {hasMore && (
+          <div className="mt-6 text-center">
+            <Button
+              onClick={loadMore}
+              disabled={loading}
+              variant="outline"
+              className="w-full sm:w-auto"
+            >
+              {loading ? 'Loading...' : 'Load More Commits'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/editor/EditorViewLayout.tsx
+++ b/components/editor/EditorViewLayout.tsx
@@ -2,8 +2,9 @@
 import { useState, useEffect } from 'react';
 import EditorFileTree from './EditorFileTree';
 import Editor from './EditorFileView';
+import CommitHistory from './CommitHistory';
 import { Button } from '@/components/ui/button';
-import { SidebarClose } from 'lucide-react';
+import { SidebarClose, FileText, GitCommit } from 'lucide-react';
 import { useMobile } from '@/hooks/use-mobile';
 
 interface EditorViewLayoutProps {
@@ -19,6 +20,7 @@ export default function EditorViewLayout({ shareData }: EditorViewLayoutProps) {
   const [access, setAccess] = useState<'checking' | 'granted' | 'denied'>('checking');
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<'code' | 'commits'>('code');
   const isMobile = useMobile();
 
   useEffect(() => {
@@ -82,42 +84,81 @@ export default function EditorViewLayout({ shareData }: EditorViewLayoutProps) {
   };
 
   return (
-    <div className="bg-bg-muted relative flex h-full overflow-hidden">
-      {/* Left sidebar  */}
-      <div className="w-0 md:w-80 md:flex-shrink-0">
-        <div
-          className={`border-border-default bg-bg-default absolute top-0 bottom-0 left-0 z-50 h-full w-80 transform border-r transition-transform duration-200 ease-out md:static md:w-auto md:translate-x-0 ${
-            isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
-          }`}
-        >
-          <div className="absolute top-2 right-2 md:hidden">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setIsSidebarOpen(false)}
-              aria-label="Close file tree"
-            >
-              <SidebarClose className="h-5 w-5" />
-            </Button>
-          </div>
-          <EditorFileTree onFileSelect={handleFileSelect} selectedFile={selectedFile} />
+    <div className="bg-bg-muted relative flex h-full flex-col overflow-hidden">
+      {/* Tab Navigation */}
+      <div className="border-border-default bg-bg-default border-b px-4">
+        <div className="flex space-x-6">
+          <button
+            onClick={() => setActiveTab('code')}
+            className={`flex items-center space-x-2 border-b-2 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'code'
+                ? 'border-fg-accent text-fg-default'
+                : 'border-transparent text-fg-muted hover:text-fg-default'
+            }`}
+          >
+            <FileText className="h-4 w-4" />
+            <span>Code</span>
+          </button>
+          <button
+            onClick={() => setActiveTab('commits')}
+            className={`flex items-center space-x-2 border-b-2 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'commits'
+                ? 'border-fg-accent text-fg-default'
+                : 'border-transparent text-fg-muted hover:text-fg-default'
+            }`}
+          >
+            <GitCommit className="h-4 w-4" />
+            <span>Commits</span>
+          </button>
         </div>
       </div>
 
-      {isSidebarOpen && (
-        <div
-          className="absolute inset-0 z-40 bg-black/40 md:hidden"
-          onClick={() => setIsSidebarOpen(false)}
-        />
-      )}
+      {/* Content Area */}
+      <div className="flex flex-1 overflow-hidden">
+        {activeTab === 'code' ? (
+          <>
+            {/* Left sidebar  */}
+            <div className="w-0 md:w-80 md:flex-shrink-0">
+              <div
+                className={`border-border-default bg-bg-default absolute top-0 bottom-0 left-0 z-50 h-full w-80 transform border-r transition-transform duration-200 ease-out md:static md:w-auto md:translate-x-0 ${
+                  isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+                }`}
+              >
+                <div className="absolute top-2 right-2 md:hidden">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setIsSidebarOpen(false)}
+                    aria-label="Close file tree"
+                  >
+                    <SidebarClose className="h-5 w-5" />
+                  </Button>
+                </div>
+                <EditorFileTree onFileSelect={handleFileSelect} selectedFile={selectedFile} />
+              </div>
+            </div>
 
-      {/* Right side  */}
-      <div className="border-border-default bg-bg-default min-w-0 flex-1 border-l shadow-sm">
-        <Editor
-          shareId={shareData.shareId}
-          selectedFile={selectedFile}
-          onSidebarOpen={() => setIsSidebarOpen(true)}
-        />
+            {isSidebarOpen && (
+              <div
+                className="absolute inset-0 z-40 bg-black/40 md:hidden"
+                onClick={() => setIsSidebarOpen(false)}
+              />
+            )}
+
+            {/* Right side  */}
+            <div className="border-border-default bg-bg-default min-w-0 flex-1 border-l shadow-sm">
+              <Editor
+                shareId={shareData.shareId}
+                selectedFile={selectedFile}
+                onSidebarOpen={() => setIsSidebarOpen(true)}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 overflow-hidden">
+            <CommitHistory shareId={shareData.shareId} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -72,3 +72,46 @@ export async function getBaseTree(repoName: string, repoOwner: string, accessTok
   const data = await response.json();
   return data;
 }
+
+export async function getCommitHistory(
+  repoName: string,
+  repoOwner: string,
+  accessToken: string,
+  page = 1,
+  perPage = 30
+) {
+  const response = await fetch(
+    `https://api.github.com/repos/${repoOwner}/${repoName}/commits?page=${page}&per_page=${perPage}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(`Failed to fetch commits: ${response.status} - ${errorData.message}`);
+  }
+
+  const commits = await response.json();
+  return commits.map((commit: any) => ({
+    sha: commit.sha,
+    message: commit.commit.message,
+    author: {
+      name: commit.commit.author.name,
+      email: commit.commit.author.email,
+      date: commit.commit.author.date,
+      avatar: commit.author?.avatar_url || null,
+      username: commit.author?.login || null,
+    },
+    committer: {
+      name: commit.commit.committer.name,
+      email: commit.commit.committer.email,
+      date: commit.commit.committer.date,
+    },
+    url: commit.html_url,
+    stats: commit.stats,
+  }));
+}


### PR DESCRIPTION
- Add getCommitHistory function to fetch commits from GitHub API
- Create CommitHistory component with GitHub-like UX
- Add tab navigation (Code/Commits) in EditorViewLayout
- Implement API route for fetching commits with session validation
- Support pagination for loading more commits
- Display commit details with author info and timestamps

Fixes #3